### PR TITLE
License link was broken when license file renamed

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,6 @@ Versioned using Semantic Versioning, <http://semver.org/>
 <http://github.com/thomasjbradley/signature-pad>
 
 ## License
-Signature Pad is licensed under the [New BSD license](https://github.com/thomasjbradley/signature-pad/blob/master/NEW-BSD-LICENSE.txt).
+Signature Pad is licensed under the [New BSD license](https://github.com/ezl/signature-pad/blob/master/LICENSE.txt).
 
 All dependencies: jQuery, json2.js, and FlashCanvas retain their own licenses.


### PR DESCRIPTION
In e0fc008b2445bf758a9efd0bf1b0630f3861ea02 the license file was renamed. This orphaned a link in the readme. Fixing it to point to the newly named license file.
